### PR TITLE
Limits

### DIFF
--- a/limits.md
+++ b/limits.md
@@ -6,8 +6,9 @@ In general, we currently allow
 * an unlimited number of services per application
 * an unlimited number of components per service
 
-However, we enforce this restriction:
+However, we enforce these restrictions:
 
 * a maximum of 10 instances (containers) per component
+* a memory (RAM) limit of 512 MB per instance (container)
 
 Please [contact us](/contact/) if you have any questions regarding this.


### PR DESCRIPTION
This change adds, for the sake of completeness, the content we had published between Dec 2 and Dec 22, 2014 at https://giantswarm.io/limits/ and which we had forgotten to push to GitHub.

Additionally, this change contains the current version f the content at https://giantswarm.io/limits/, which introduces a memory limit for all instances (containers) of 512 MB.
