### PR TITLE
stopped -> deleted

### DIFF
--- a/limits.md
+++ b/limits.md
@@ -8,7 +8,7 @@ In general, we currently allow
 
 However, we enforce these restrictions:
 
-* any application older than 7 days (from creation time) needs a custom domain name to keep running, otherwise it will be stopped
+* any application older than 7 days (from creation time) needs a custom domain name to keep running, otherwise it will be deleted
 * a maximum of 10 instances (containers) per component
 * a memory (RAM) limit of 512 MB per instance (container)
 * a storage size limit of 100 GB per volume


### PR DESCRIPTION
Instead of stopping an application but letting it exist, we changed our mechanism to delete an application without custom domain 7 days after creation to free resources.